### PR TITLE
feat: serve well-known nostr.json via build-time fetch

### DIFF
--- a/src/pages/.well-known/nostr.json.md
+++ b/src/pages/.well-known/nostr.json.md
@@ -1,7 +1,0 @@
----
-layout: ../../layouts/redirect.astro
-title: "Nostr well-known for relay.dyne.org"
-description: "Nostr is the way, Satoshi is the Prophet."
-destination: "https://relay.dyne.org/.well-known/nostr.json"
----
-

--- a/src/pages/.well-known/nostr.json.ts
+++ b/src/pages/.well-known/nostr.json.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+
+const UPSTREAM = 'https://relay.dyne.org/.well-known/nostr.json';
+
+export const GET: APIRoute = async () => {
+	const res = await fetch(UPSTREAM);
+	if (!res.ok) {
+		throw new Error(`Failed to fetch ${UPSTREAM}: ${res.status} ${res.statusText}`);
+	}
+	const body = await res.text();
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'application/json; charset=utf-8',
+			'Access-Control-Allow-Origin': '*',
+		},
+	});
+};


### PR DESCRIPTION
Replace meta-refresh redirect with a static Astro endpoint that fetches
relay.dyne.org's nostr.json at build time, so curl and other non-browser
clients get real JSON instead of an HTML redirect page.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
